### PR TITLE
Add installation of `patchelf` to Dockerfile

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -24,6 +24,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
         python3-distutils \
         python3-pip \
         unzip \
+        patchelf \
     && rm -rf /var/lib/apt/lists/*
 
 # Build the CPLEX solver if available, otherwise fall back to SCIP.


### PR DESCRIPTION
Hello, I am an organizer of the [Core Challenge 2023 ](https://core-challenge.github.io/2023/).

We found the [following messages](https://github.com/AI-Planning/core-challenge-2023/actions/runs/4898482097/jobs/8747614699#step:6:2228) during the execution of `scip_installer.sh` in `docker build`:
```console
...
SCIPOptSuite Installer Version: 8.0.3, Copyright (c) Zuse Institute Berlin
This is a self-extracting archive.
The archive will be extracted to: /scip

Using target directory: /scip
Extracting, please wait...

Relinking libraries
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
/scip_installer.sh: 183: patchelf: not found
Unpacking finished successfully
...
```

Although the script says it is successful, we guess it is not an intended behavior.

This request fixes this issue by simply installing the `patchelf` package in the builder step.

Please merge this request if this change is OK for you.
